### PR TITLE
Add initial to expected_list (fix failing test)

### DIFF
--- a/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/__init__.py
@@ -12,6 +12,7 @@ from .keep import Keep
 from .mask import Mask
 from .redact import Redact
 from .replace import Replace
+from .initial import Initial
 
 try:
     from .ahds_surrogate import AHDSSurrogate
@@ -37,6 +38,7 @@ __all__ = [
     "AESCipher",
     "OperatorsFactory",
     "AHDS_AVAILABLE",
+    "Initial",
 ]
 
 if AHDS_AVAILABLE:

--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -9,10 +9,17 @@ class Initial(Operator):
 	"""Return the first character of the provided text"""
 
 	def operate(self, text: str = None, params: Dict = None) -> str:
-		"""Return the initial character of the text or empty string"""
+		"""Return the initials for the provided text or empty string"""
 		if not text:
 			return ""
-		return text[0]
+
+		# Split on whitespace and ignore empty tokens
+		tokens = [t for t in text.split() if t]
+		if not tokens:
+			return ""
+
+		initials = [f"{t[0].upper()}." for t in tokens]
+		return " ".join(initials)
 
 	def validate(self, params: Dict = None) -> None:
 		"""No parameters are required for this operator"""

--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -1,0 +1,28 @@
+"""Initial operator - This operator keeps the initial character of the input text"""
+
+from typing import Dict
+
+from presidio_anonymizer.operators import Operator, OperatorType
+
+
+class Initial(Operator):
+	"""Return the first character of the provided text"""
+
+	def operate(self, text: str = None, params: Dict = None) -> str:
+		"""Return the initial character of the text or empty string"""
+		if not text:
+			return ""
+		return text[0]
+
+	def validate(self, params: Dict = None) -> None:
+		"""No parameters are required for this operator"""
+		pass
+
+	def operator_name(self) -> str:
+		"""Return operator name"""
+		return "initial"
+
+	def operator_type(self) -> OperatorType:
+		"""Return operator type (Anonymize)"""
+		return OperatorType.Anonymize
+

--- a/presidio-anonymizer/presidio_anonymizer/operators/initial.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/initial.py
@@ -18,7 +18,16 @@ class Initial(Operator):
 		if not tokens:
 			return ""
 
-		initials = [f"{t[0].upper()}." for t in tokens]
+		def token_initial(tok: str) -> str:
+			# find first alphanumeric character and preserve anything before it
+			for idx, ch in enumerate(tok):
+				if ch.isalnum():
+					pref = tok[:idx]
+					ch_out = ch.upper() if ch.isalpha() else ch
+					return f"{pref}{ch_out}."
+			return tok
+
+		initials = [token_initial(t) for t in tokens]
 		return " ".join(initials)
 
 	def validate(self, params: Dict = None) -> None:

--- a/presidio-anonymizer/presidio_anonymizer/operators/operators_factory.py
+++ b/presidio-anonymizer/presidio_anonymizer/operators/operators_factory.py
@@ -12,6 +12,7 @@ from presidio_anonymizer.operators import (
     Hash,
     Keep,
     Mask,
+    Initial,
     Operator,
     OperatorType,
     Redact,
@@ -21,7 +22,7 @@ from presidio_anonymizer.operators import (
 logger = logging.getLogger("presidio-anonymizer")
 
 # Predefined operators
-ANONYMIZERS = [Custom, Encrypt, Hash, Keep, Mask, Redact, Replace]
+ANONYMIZERS = [Custom, Encrypt, Hash, Keep, Mask, Redact, Replace, Initial]
 if AHDS_AVAILABLE and AHDSSurrogate:
     ANONYMIZERS.append(AHDSSurrogate)
 

--- a/presidio-anonymizer/tests/operators/test_initial.py
+++ b/presidio-anonymizer/tests/operators/test_initial.py
@@ -10,6 +10,8 @@ def test_correct_name():
     "input_text, initials",
     [
         ("John Smith", "J. S."),
+        ("@abc", "@A."),
+        ("@843A", "@8."),
     ],
 )
 def test_given_value_for_initial(input_text, initials):

--- a/presidio-anonymizer/tests/operators/test_initial.py
+++ b/presidio-anonymizer/tests/operators/test_initial.py
@@ -15,3 +15,7 @@ def test_correct_name():
 def test_given_value_for_initial(input_text, initials):
     result = Initial().operate(input_text)
     assert result == initials
+
+
+def test_removes_extra_whitespace():
+    assert Initial().operate("  John   Smith  ") == "J. S."

--- a/presidio-anonymizer/tests/operators/test_initial.py
+++ b/presidio-anonymizer/tests/operators/test_initial.py
@@ -2,15 +2,16 @@ from presidio_anonymizer.operators import Initial
 import pytest
 
 
+def test_correct_name():
+    assert Initial().operator_name() == "initial"
+
+
 @pytest.mark.parametrize(
     "input_text, initials",
     [
         ("John Smith", "J. S."),
     ],
 )
-def test_correct_name():
-    assert Initial().operator_name() == "initial"
-
 def test_given_value_for_initial(input_text, initials):
-    text = Initial().operate(input_text) == initials
-    assert text == initials
+    result = Initial().operate(input_text)
+    assert result == initials

--- a/presidio-anonymizer/tests/operators/test_initial.py
+++ b/presidio-anonymizer/tests/operators/test_initial.py
@@ -1,0 +1,16 @@
+from presidio_anonymizer.operators import Initial
+import pytest
+
+
+@pytest.mark.parametrize(
+    "input_text, initials",
+    [
+        ("John Smith", "J. S."),
+    ],
+)
+def test_correct_name():
+    assert Initial().operator_name() == "initial"
+
+def test_given_value_for_initial(input_text, initials):
+    text = Initial().operate(input_text) == initials
+    assert text == initials

--- a/presidio-anonymizer/tests/test_anonymizer_engine.py
+++ b/presidio-anonymizer/tests/test_anonymizer_engine.py
@@ -17,7 +17,7 @@ from presidio_anonymizer.operators import OperatorType, AHDS_AVAILABLE
 
 def test_given_request_anonymizers_return_list():
     engine = AnonymizerEngine()
-    expected_list = {"hash", "mask", "redact", "replace", "custom", "keep", "encrypt"}
+    expected_list = {"hash", "mask", "redact", "replace", "custom", "keep", "encrypt", "initial"}
     if AHDS_AVAILABLE:
         expected_list.add("surrogate_ahds")
     anon_list = set(engine.get_anonymizers())


### PR DESCRIPTION
### Summary

- This PR adds the missing `initial` anonymizer operator so the anonymizer engine exposes the expected set of anonymizers

### Why

- The CI test run shows the test failing because `initial` is not present in the engine's anonymizer list

### What I will change

- Add a new operator implementation
- Wire the new operator into the operator's factory so it can be instantiated 
- Ensure anonymizer engine includes `initial ` in its returned list